### PR TITLE
Aldwin Vlasblom credit link update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ Defines if redirect responses should be followed automatically.
 ## Thanks
 
 * [Sindre Sorhus](https://github.com/sindresorhus) for `got` and the docs
-* [Aldwin Vlasblom](https://github.com/fluture-js/Fluture) for `fluture`
+* [Aldwin Vlasblom](https://github.com/Avaq) for `fluture`
 
 ## License
 


### PR DESCRIPTION
Change the link for crediting Aldwin Vlasblom from the url of the fluture repo to Aldwin's Github account url: https://github.com/Avaq